### PR TITLE
refactor: use whiskers

### DIFF
--- a/catppuccin-frappe.rstheme
+++ b/catppuccin-frappe.rstheme
@@ -1,154 +1,144 @@
 /* rs-theme-name: catppuccin-frappe */
 /* rs-theme-is-dark: TRUE */
 
-/* based on auto-generated theme with manual adjustments */
-
-/*
-  A few shaed bassed on Surface1 are semi-transparent, which requires using the rgba() function
-  If this needs to be adjusted, search for "CHECKME: semi-transparent version of Surface1" to find this in the document
-*/ 
-
 :root {
-  --Rosewater: #f2d5cf;
-  --Flamingo: #eebebe;
-  --Pink: #f4b8e4;
-  --Mauve: #ca9ee6;
-  --Red: #e78284;
-  --Maroon: #ea999c;
-  --Peach: #ef9f76;
-  --Yellow: #e5c890;
-  --Green: #a6d189;
-  --Teal: #81c8be;
-  --Sky: #99d1db;
-  --Sapphire: #85c1dc;
-  --Blue: #8caaee;
-  --Lavender: #babbf1;
-  --Text: #c6d0f5;
-  --Subtext1: #b5bfe2;
-  --Subtext0: #a5adce;
-  --Overlay2: #949cbb;
-  --Overlay1: #838ba7;
-  --Overlay0: #737994;
-  --Surface2: #626880;
-  --Surface1: #51576d;
-  --Surface0: #414559;
-  --Base: #303446;
-  --Mantle: #292c3c;
-  --Crust: #232634;
+  --rosewater: #f2d5cf;
+  --flamingo: #eebebe;
+  --pink: #f4b8e4;
+  --mauve: #ca9ee6;
+  --red: #e78284;
+  --maroon: #ea999c;
+  --peach: #ef9f76;
+  --yellow: #e5c890;
+  --green: #a6d189;
+  --teal: #81c8be;
+  --sky: #99d1db;
+  --sapphire: #85c1dc;
+  --blue: #8caaee;
+  --lavender: #babbf1;
+  --text: #c6d0f5;
+  --subtext1: #b5bfe2;
+  --subtext0: #a5adce;
+  --overlay2: #949cbb;
+  --overlay1: #838ba7;
+  --overlay0: #737994;
+  --surface2: #626880;
+  --surface1: #51576d;
+  --surface0: #414559;
+  --base: #303446;
+  --mantle: #292c3c;
+  --crust: #232634;
 }
 
 .ace_gutter {
-  background: var(--Base);
-  color: var(--Subtext0); /* other theme sets this to #838995, but this is not part of Nord palette */
+  background: var(--base);
+  color: var(--subtext0); /* other theme sets this to #838995, but this is not part of Nord palette */
 }
 
 .ace_gutter-active-line {
-  background: var(--Surface1); /* other theme sets transparency to 0.32 */
+  background: var(--surface1); /* other theme sets transparency to 0.32 */
 }
 
 .ace_print-margin {
   width: 1px;
-  background: var(--Surface0); /* other theme sets this to #e8e8e8, but this is not part of Nord palette */
+  background: var(--surface0); /* other theme sets this to #e8e8e8, but this is not part of Nord palette */
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--Base);
-  color: var(--Subtext0);
+  background-color: var(--base);
+  color: var(--subtext0);
 }
 
 .ace_cursor {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_selection {
-  background: rgba(67, 76, 94, 0.80); /* Surface1, semi-transparent */
+  background: rgba(81, 87, 109, 0.80);
 }
 
 
 .ace_selection.ace_start {
-  box-shadow: 0 0 3px 0px var(--Base);
+  box-shadow: 0 0 3px 0px var(--base);
   border-radius: 2px;
 }
 
 /* unclear function, could not find in documentation */
 .ace_marker-layer .ace_step {
-  background: var(--Surface0); /* other theme sets this to rgb(198, 219, 174), but this is not part of Nord palette */
+  background: var(--surface0); /* other theme sets this to rgb(198, 219, 174), but this is not part of Nord palette */
 }
 
 /* Changes the color and style of the highlighting on matching brackets. */
 .ace_marker-layer .ace_bracket {
   margin: -1px 0 0 -1px;
-  border: 1px solid var(--Text); /* other theme sets this to Surface2, but not clear why */
+  border: 1px solid var(--text); /* other theme sets this to Surface2, but not clear why */
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_active-line {
-  background: rgba(67, 76, 94, 0.32); /* Surface1, semi-transparent */
+  background: rgba(81, 87, 109, 0.32);
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid rgba(67, 76, 94, 0.80); /* Surface1, semi-transparent */
+  border: 1px solid rgba(81, 87, 109, 0.80);
 }
 
 .ace_fold {
-  background-color: var(--Sapphire);
-  border-color: var(--Surface0); /* Surface0 is standard color for borders, but other theme has used Subtext0 here */
+  background-color: var(--sapphire);
+  border-color: var(--surface0); /* Surface0 is standard color for borders, but other theme has used Subtext0 here */
 }
 
-/* whitespace / line break characters - usually invisible, but can be switched to visible in the preferences */ 
+/* whitespace / line break characters - usually invisible, but can be switched to visible in the preferences */
 .ace_invisible {
-  color: var(--Surface2);
+  color: var(--surface2);
 }
 
 .ace_keyword, ace_meta {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 .ace_keyword.ace_operator {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 /* language constants like TRUE and  FALSE */
 .ace_constant.ace_language {
-  color: var(--Blue);
+  color: var(--blue);
 
 }
 
 .ace_constant.ace_numeric {
-  color: var(--Mauve);
+  color: var(--mauve);
 
 }
 
 /* probably referring to escape characters, but not entirely clear */
 .ace_constant.ace_character.ace_escape {
-  color: var(--Yellow);
+  color: var(--yellow);
 }
 
 .ace_constant.ace_other {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 
 }
 
 /* Changes the color and style of code blocks in RMarkdown documents. */
 .ace_support.ace_function {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 
 }
 
 .ace_support.ace_constant {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_support.ace_class {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_support.ace_type {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
@@ -156,102 +146,102 @@
 .ace_meta.ace_tag,
 .ace_storage,
 .ace_storage.ace_type {
-  color: var(--Blue);
+  color: var(--blue);
 
 }
 
 .ace_invalid.ace_illegal {
-  color: var(--Subtext0);
-  background-color: var(--Red);
+  color: var(--subtext0);
+  background-color: var(--red);
 }
 
 .ace_invalid.ace_deprecated {
-  color: var(--Subtext0);
-  background-color: var(--Yellow);
+  color: var(--subtext0);
+  background-color: var(--yellow);
 }
 
 .ace_string {
-  color: var(--Green);
+  color: var(--green);
 }
 
 .ace_string.ace_regexp {
-  color: var(--Yellow);
+  color: var(--yellow);
 }
 
 .ace_comment {
-  color: var(--Surface2);
+  color: var(--surface2);
 
 }
 
 /* could not find documentation, but looks very high-level. unclear what it actually is */
 .ace_variable {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 /* could not find documentation, but looks very high-level. unclear what it actually is */
 .ace_variable.ace_language {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 .ace_variable.ace_parameter {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 
 }
 
 .ace_entity.ace_other,
 .ace_entity.ace_other.ace_attribute-name {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_entity.ace_name.ace_function {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 /* Characters that start a heading in RMarkdown documents. */
 .ace_markup.ace_heading {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 .nocolor.ace_editor .ace_line span {
-  color: var(--Subtext0) !important;
+  color: var(--subtext0) !important;
 }
 
 .ace_bracket {
   margin: 0 !important;
   border: 0 !important;
   background-color: rgba(128, 128, 128, 0.5);
-  color: var(--Text);
+  color: var(--text);
 }
 
 .ace_marker-layer .ace_foreign_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Base);
+  background-color: var(--base);
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Surface1);
+  background-color: var(--surface1);
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Surface1);
+  background-color: var(--surface1);
 }
 
 .ace_console_error {
-  background-color: var(--Surface1);
-  color: var(--Red) !important;
+  background-color: var(--surface1);
+  color: var(--red) !important;
 }
 
 #rstudio_console_output .ace_constant.ace_language {
-  color: var(--Red) !important;
+  color: var(--red) !important;
 }
 
 .terminal {
-  background-color: var(--Base);
-  color: var(--Subtext0);
+  background-color: var(--base);
+  color: var(--subtext0);
   font-feature-settings: "liga" 0;
   position: relative;
   user-select: none;
@@ -280,7 +270,7 @@
    background-color: #CCC;
 }
 .terminal .xterm-viewport {
-  background-color: var(--Base);
+  background-color: var(--base);
   overflow-y: scroll;
 }
 
@@ -301,9 +291,9 @@
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .ace_editor.ace_autocomplete {
-    background: var(--Surface0);
-    border: solid 1px var(--Surface2) !important;
-    color: var(--Subtext0);
+    background: var(--surface0);
+    border: solid 1px var(--surface2) !important;
+    color: var(--subtext0);
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line,

--- a/catppuccin-macchiato.rstheme
+++ b/catppuccin-macchiato.rstheme
@@ -1,154 +1,144 @@
 /* rs-theme-name: catppuccin-macchiato */
 /* rs-theme-is-dark: TRUE */
 
-/* based on manual adjustments */
-
-/*
-  A few shaed bassed on Surface1 are semi-transparent, which requires using the rgba() function
-  If this needs to be adjusted, search for "CHECKME: semi-transparent version of Surface1" to find this in the document
-*/ 
-
 :root {
-  --Rosewater: #f4dbd6;
-  --Flamingo: #f0c6c6;
-  --Pink: #f5bde6;
-  --Mauve: #c6a0f6;
-  --Red: #ed8796;
-  --Maroon: #ee99a0;
-  --Peach: #f5a97f;
-  --Yellow: #eed49f;
-  --Green: #a6da95;
-  --Teal: #8bd5ca;
-  --Sky: #91d7e3;
-  --Sapphire: #7dc4e4;
-  --Blue: #8aadf4;
-  --Lavender: #b7bdf8;
-  --Text: #cad3f5;
-  --Subtext1: #b8c0e0;
-  --Subtext0: #a5adcb;
-  --Overlay2: #939ab7;
-  --Overlay1: #8087a2;
-  --Overlay0: #6e738d;
-  --Surface2: #5b6078;
-  --Surface1: #494d64;
-  --Surface0: #363a4f;
-  --Base: #24273a;
-  --Mantle: #1e2030;
-  --Crust: #181926;
+  --rosewater: #f4dbd6;
+  --flamingo: #f0c6c6;
+  --pink: #f5bde6;
+  --mauve: #c6a0f6;
+  --red: #ed8796;
+  --maroon: #ee99a0;
+  --peach: #f5a97f;
+  --yellow: #eed49f;
+  --green: #a6da95;
+  --teal: #8bd5ca;
+  --sky: #91d7e3;
+  --sapphire: #7dc4e4;
+  --blue: #8aadf4;
+  --lavender: #b7bdf8;
+  --text: #cad3f5;
+  --subtext1: #b8c0e0;
+  --subtext0: #a5adcb;
+  --overlay2: #939ab7;
+  --overlay1: #8087a2;
+  --overlay0: #6e738d;
+  --surface2: #5b6078;
+  --surface1: #494d64;
+  --surface0: #363a4f;
+  --base: #24273a;
+  --mantle: #1e2030;
+  --crust: #181926;
 }
 
 .ace_gutter {
-  background: var(--Base);
-  color: var(--Subtext0); 
+  background: var(--base);
+  color: var(--subtext0); /* other theme sets this to #838995, but this is not part of Nord palette */
 }
 
 .ace_gutter-active-line {
-  background: var(--Surface1); /* other theme sets transparency to 0.32 */
+  background: var(--surface1); /* other theme sets transparency to 0.32 */
 }
 
 .ace_print-margin {
   width: 1px;
-  background: var(--Surface0); 
+  background: var(--surface0); /* other theme sets this to #e8e8e8, but this is not part of Nord palette */
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--Base);
-  color: var(--Subtext0);
+  background-color: var(--base);
+  color: var(--subtext0);
 }
 
 .ace_cursor {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_selection {
-  background: rgba(73, 77, 100, 0.32); /* Surface1, semi-transparent */
+  background: rgba(73, 77, 100, 0.80);
 }
 
 
 .ace_selection.ace_start {
-  box-shadow: 0 0 3px 0px var(--Base);
+  box-shadow: 0 0 3px 0px var(--base);
   border-radius: 2px;
 }
 
 /* unclear function, could not find in documentation */
 .ace_marker-layer .ace_step {
-  background: var(--Surface0); 
+  background: var(--surface0); /* other theme sets this to rgb(198, 219, 174), but this is not part of Nord palette */
 }
 
 /* Changes the color and style of the highlighting on matching brackets. */
 .ace_marker-layer .ace_bracket {
   margin: -1px 0 0 -1px;
-  border: 1px solid var(--Text); /* other theme sets this to Surface2, but not clear why */
+  border: 1px solid var(--text); /* other theme sets this to Surface2, but not clear why */
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_active-line {
-  background: rgba(73, 77, 100, 0.80); /* Surface1, semi-transparent */
+  background: rgba(73, 77, 100, 0.32);
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid rgba(73, 77, 100, 0.80); /* Surface1, semi-transparent */
+  border: 1px solid rgba(73, 77, 100, 0.80);
 }
 
 .ace_fold {
-  background-color: var(--Sapphire);
-  border-color: var(--Surface0); /* Surface0 is standard color for borders, but other theme has used Subtext0 here */
+  background-color: var(--sapphire);
+  border-color: var(--surface0); /* Surface0 is standard color for borders, but other theme has used Subtext0 here */
 }
 
-/* whitespace / line break characters - usually invisible, but can be switched to visible in the preferences */ 
+/* whitespace / line break characters - usually invisible, but can be switched to visible in the preferences */
 .ace_invisible {
-  color: var(--Surface2);
+  color: var(--surface2);
 }
 
 .ace_keyword, ace_meta {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 .ace_keyword.ace_operator {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 /* language constants like TRUE and  FALSE */
 .ace_constant.ace_language {
-  color: var(--Blue);
+  color: var(--blue);
 
 }
 
 .ace_constant.ace_numeric {
-  color: var(--Mauve);
+  color: var(--mauve);
 
 }
 
 /* probably referring to escape characters, but not entirely clear */
 .ace_constant.ace_character.ace_escape {
-  color: var(--Yellow);
+  color: var(--yellow);
 }
 
 .ace_constant.ace_other {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 
 }
 
 /* Changes the color and style of code blocks in RMarkdown documents. */
 .ace_support.ace_function {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 
 }
 
 .ace_support.ace_constant {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_support.ace_class {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_support.ace_type {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
@@ -156,102 +146,102 @@
 .ace_meta.ace_tag,
 .ace_storage,
 .ace_storage.ace_type {
-  color: var(--Blue);
+  color: var(--blue);
 
 }
 
 .ace_invalid.ace_illegal {
-  color: var(--Subtext0);
-  background-color: var(--Red);
+  color: var(--subtext0);
+  background-color: var(--red);
 }
 
 .ace_invalid.ace_deprecated {
-  color: var(--Subtext0);
-  background-color: var(--Yellow);
+  color: var(--subtext0);
+  background-color: var(--yellow);
 }
 
 .ace_string {
-  color: var(--Green);
+  color: var(--green);
 }
 
 .ace_string.ace_regexp {
-  color: var(--Yellow);
+  color: var(--yellow);
 }
 
 .ace_comment {
-  color: var(--Surface2);
+  color: var(--surface2);
 
 }
 
 /* could not find documentation, but looks very high-level. unclear what it actually is */
 .ace_variable {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 /* could not find documentation, but looks very high-level. unclear what it actually is */
 .ace_variable.ace_language {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 .ace_variable.ace_parameter {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 
 }
 
 .ace_entity.ace_other,
 .ace_entity.ace_other.ace_attribute-name {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_entity.ace_name.ace_function {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 /* Characters that start a heading in RMarkdown documents. */
 .ace_markup.ace_heading {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 .nocolor.ace_editor .ace_line span {
-  color: var(--Subtext0) !important;
+  color: var(--subtext0) !important;
 }
 
 .ace_bracket {
   margin: 0 !important;
   border: 0 !important;
   background-color: rgba(128, 128, 128, 0.5);
-  color: var(--Text);
+  color: var(--text);
 }
 
 .ace_marker-layer .ace_foreign_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Base);
+  background-color: var(--base);
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Surface1);
+  background-color: var(--surface1);
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Surface1);
+  background-color: var(--surface1);
 }
 
 .ace_console_error {
-  background-color: var(--Surface1);
-  color: var(--Red) !important;
+  background-color: var(--surface1);
+  color: var(--red) !important;
 }
 
 #rstudio_console_output .ace_constant.ace_language {
-  color: var(--Red) !important;
+  color: var(--red) !important;
 }
 
 .terminal {
-  background-color: var(--Base);
-  color: var(--Subtext0);
+  background-color: var(--base);
+  color: var(--subtext0);
   font-feature-settings: "liga" 0;
   position: relative;
   user-select: none;
@@ -280,7 +270,7 @@
    background-color: #CCC;
 }
 .terminal .xterm-viewport {
-  background-color: var(--Base);
+  background-color: var(--base);
   overflow-y: scroll;
 }
 
@@ -301,9 +291,9 @@
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .ace_editor.ace_autocomplete {
-    background: var(--Surface0);
-    border: solid 1px var(--Surface2) !important;
-    color: var(--Subtext0);
+    background: var(--surface0);
+    border: solid 1px var(--surface2) !important;
+    color: var(--subtext0);
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line,

--- a/catppuccin-mocha.rstheme
+++ b/catppuccin-mocha.rstheme
@@ -1,154 +1,144 @@
 /* rs-theme-name: catppuccin-mocha */
 /* rs-theme-is-dark: TRUE */
 
-/* based on manual adjustments */
-
-/*
-  A few shaed bassed on Surface1 are semi-transparent, which requires using the rgba() function
-  If this needs to be adjusted, search for "CHECKME: semi-transparent version of Surface1" to find this in the document
-*/ 
-
 :root {
-  --Rosewater: #f5e0dc;
-  --Flamingo: #f2cdcd;
-  --Pink: #f5c2e7;
-  --Mauve: #cba6f7;
-  --Red: #f38ba8;
-  --Maroon: #eba0ac;
-  --Peach: #fab387;
-  --Yellow: #f9e2af;
-  --Green: #a6e3a1;
-  --Teal: #94e2d5;
-  --Sky: #89dceb;
-  --Sapphire: #74c7ec;
-  --Blue: #89b4fa;
-  --Lavender: #b4befe;
-  --Text: #cdd6f4;
-  --Subtext1: #bac2de;
-  --Subtext0: #a6adc8;
-  --Overlay2: #9399b2;
-  --Overlay1: #7f849c;
-  --Overlay0: #6c7086;
-  --Surface2: #585b70;
-  --Surface1: #45475a;
-  --Surface0: #313244;
-  --Base: #1e1e2e;
-  --Mantle: #181825;
-  --Crust: #11111b;
+  --rosewater: #f5e0dc;
+  --flamingo: #f2cdcd;
+  --pink: #f5c2e7;
+  --mauve: #cba6f7;
+  --red: #f38ba8;
+  --maroon: #eba0ac;
+  --peach: #fab387;
+  --yellow: #f9e2af;
+  --green: #a6e3a1;
+  --teal: #94e2d5;
+  --sky: #89dceb;
+  --sapphire: #74c7ec;
+  --blue: #89b4fa;
+  --lavender: #b4befe;
+  --text: #cdd6f4;
+  --subtext1: #bac2de;
+  --subtext0: #a6adc8;
+  --overlay2: #9399b2;
+  --overlay1: #7f849c;
+  --overlay0: #6c7086;
+  --surface2: #585b70;
+  --surface1: #45475a;
+  --surface0: #313244;
+  --base: #1e1e2e;
+  --mantle: #181825;
+  --crust: #11111b;
 }
 
 .ace_gutter {
-  background: var(--Base);
-  color: var(--Subtext0);
+  background: var(--base);
+  color: var(--subtext0); /* other theme sets this to #838995, but this is not part of Nord palette */
 }
 
 .ace_gutter-active-line {
-  background: var(--Surface1); /* other theme sets transparency to 0.32 */
+  background: var(--surface1); /* other theme sets transparency to 0.32 */
 }
 
 .ace_print-margin {
   width: 1px;
-  background: var(--Surface0);
+  background: var(--surface0); /* other theme sets this to #e8e8e8, but this is not part of Nord palette */
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--Base);
-  color: var(--Subtext0);
+  background-color: var(--base);
+  color: var(--subtext0);
 }
 
 .ace_cursor {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_selection {
-  background: rgba(69, 71, 90, 0.80); /* Surface1, semi-transparent */
+  background: rgba(69, 71, 90, 0.80);
 }
 
 
 .ace_selection.ace_start {
-  box-shadow: 0 0 3px 0px var(--Base);
+  box-shadow: 0 0 3px 0px var(--base);
   border-radius: 2px;
 }
 
 /* unclear function, could not find in documentation */
 .ace_marker-layer .ace_step {
-  background: var(--Surface0);
+  background: var(--surface0); /* other theme sets this to rgb(198, 219, 174), but this is not part of Nord palette */
 }
 
 /* Changes the color and style of the highlighting on matching brackets. */
 .ace_marker-layer .ace_bracket {
   margin: -1px 0 0 -1px;
-  border: 1px solid var(--Text); /* other theme sets this to Surface2, but not clear why */
+  border: 1px solid var(--text); /* other theme sets this to Surface2, but not clear why */
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_active-line {
-  background: rgba(69, 71, 90, 0.32); /* Surface1, semi-transparent */
+  background: rgba(69, 71, 90, 0.32);
 }
 
-/* CHECKME: semi-transparent version of Surface1, needs to be updated manually */
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid rgba(69, 71, 90, 0.80); /* Surface1, semi-transparent */
+  border: 1px solid rgba(69, 71, 90, 0.80);
 }
 
 .ace_fold {
-  background-color: var(--Sapphire);
-  border-color: var(--Surface0); /* Surface0 is standard color for borders, but other theme has used Subtext0 here */
+  background-color: var(--sapphire);
+  border-color: var(--surface0); /* Surface0 is standard color for borders, but other theme has used Subtext0 here */
 }
 
-/* whitespace / line break characters - usually invisible, but can be switched to visible in the preferences */ 
+/* whitespace / line break characters - usually invisible, but can be switched to visible in the preferences */
 .ace_invisible {
-  color: var(--Surface2);
+  color: var(--surface2);
 }
 
 .ace_keyword, ace_meta {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 .ace_keyword.ace_operator {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 /* language constants like TRUE and  FALSE */
 .ace_constant.ace_language {
-  color: var(--Blue);
+  color: var(--blue);
 
 }
 
 .ace_constant.ace_numeric {
-  color: var(--Mauve);
+  color: var(--mauve);
 
 }
 
 /* probably referring to escape characters, but not entirely clear */
 .ace_constant.ace_character.ace_escape {
-  color: var(--Yellow);
+  color: var(--yellow);
 }
 
 .ace_constant.ace_other {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 
 }
 
 /* Changes the color and style of code blocks in RMarkdown documents. */
 .ace_support.ace_function {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 
 }
 
 .ace_support.ace_constant {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_support.ace_class {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_support.ace_type {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
@@ -156,102 +146,102 @@
 .ace_meta.ace_tag,
 .ace_storage,
 .ace_storage.ace_type {
-  color: var(--Blue);
+  color: var(--blue);
 
 }
 
 .ace_invalid.ace_illegal {
-  color: var(--Subtext0);
-  background-color: var(--Red);
+  color: var(--subtext0);
+  background-color: var(--red);
 }
 
 .ace_invalid.ace_deprecated {
-  color: var(--Subtext0);
-  background-color: var(--Yellow);
+  color: var(--subtext0);
+  background-color: var(--yellow);
 }
 
 .ace_string {
-  color: var(--Green);
+  color: var(--green);
 }
 
 .ace_string.ace_regexp {
-  color: var(--Yellow);
+  color: var(--yellow);
 }
 
 .ace_comment {
-  color: var(--Surface2);
+  color: var(--surface2);
 
 }
 
 /* could not find documentation, but looks very high-level. unclear what it actually is */
 .ace_variable {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 /* could not find documentation, but looks very high-level. unclear what it actually is */
 .ace_variable.ace_language {
-  color: var(--Blue);
+  color: var(--blue);
 }
 
 .ace_variable.ace_parameter {
-  color: var(--Subtext0);
+  color: var(--subtext0);
 
 }
 
 .ace_entity.ace_other,
 .ace_entity.ace_other.ace_attribute-name {
-  color: var(--Teal);
+  color: var(--teal);
 
 }
 
 .ace_entity.ace_name.ace_function {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 /* Characters that start a heading in RMarkdown documents. */
 .ace_markup.ace_heading {
-  color: var(--Sapphire);
+  color: var(--sapphire);
 }
 
 .nocolor.ace_editor .ace_line span {
-  color: var(--Subtext0) !important;
+  color: var(--subtext0) !important;
 }
 
 .ace_bracket {
   margin: 0 !important;
   border: 0 !important;
   background-color: rgba(128, 128, 128, 0.5);
-  color: var(--Text);
+  color: var(--text);
 }
 
 .ace_marker-layer .ace_foreign_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Base);
+  background-color: var(--base);
 }
 .ace_marker-layer .ace_active_debug_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Surface1);
+  background-color: var(--surface1);
 }
 .ace_marker-layer .ace_find_line {
   position: absolute;
   z-index: -1;
-  background-color: var(--Surface1);
+  background-color: var(--surface1);
 }
 
 .ace_console_error {
-  background-color: var(--Surface1);
-  color: var(--Red) !important;
+  background-color: var(--surface1);
+  color: var(--red) !important;
 }
 
 #rstudio_console_output .ace_constant.ace_language {
-  color: var(--Red) !important;
+  color: var(--red) !important;
 }
 
 .terminal {
-  background-color: var(--Base);
-  color: var(--Subtext0);
+  background-color: var(--base);
+  color: var(--subtext0);
   font-feature-settings: "liga" 0;
   position: relative;
   user-select: none;
@@ -280,7 +270,7 @@
    background-color: #CCC;
 }
 .terminal .xterm-viewport {
-  background-color: var(--Base);
+  background-color: var(--base);
   overflow-y: scroll;
 }
 
@@ -301,9 +291,9 @@
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .ace_editor.ace_autocomplete {
-    background: var(--Surface0);
-    border: solid 1px var(--Surface2) !important;
-    color: var(--Subtext0);
+    background: var(--surface0);
+    border: solid 1px var(--surface2) !important;
+    color: var(--subtext0);
 }
 
 .rstudio-themes-flat.rstudio-themes-dark-menus .ace_editor.ace_autocomplete .ace_marker-layer .ace_active-line,

--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers rstudio.tera

--- a/rstudio.tera
+++ b/rstudio.tera
@@ -1,33 +1,21 @@
-/* rs-theme-name: catppuccin-latte */
-/* rs-theme-is-dark: FALSE */
+---
+whiskers:
+  version: "2.2.0"
+  matrix:
+    - flavor
+  filename: "catppuccin-{{ flavor.identifier }}.rstheme"
+---
+
+{%- set surface1_80 = surface1 | mod(opacity=0.8) -%}
+{%- set surface1_32 = surface1 | mod(opacity=0.32) -%}
+
+/* rs-theme-name: catppuccin-{{ flavor.identifier }} */
+/* rs-theme-is-dark: {% if flavor.dark %}TRUE{% else %}FALSE{% endif %} */
 
 :root {
-  --rosewater: #dc8a78;
-  --flamingo: #dd7878;
-  --pink: #ea76cb;
-  --mauve: #8839ef;
-  --red: #d20f39;
-  --maroon: #e64553;
-  --peach: #fe640b;
-  --yellow: #df8e1d;
-  --green: #40a02b;
-  --teal: #179299;
-  --sky: #04a5e5;
-  --sapphire: #209fb5;
-  --blue: #1e66f5;
-  --lavender: #7287fd;
-  --text: #4c4f69;
-  --subtext1: #5c5f77;
-  --subtext0: #6c6f85;
-  --overlay2: #7c7f93;
-  --overlay1: #8c8fa1;
-  --overlay0: #9ca0b0;
-  --surface2: #acb0be;
-  --surface1: #bcc0cc;
-  --surface0: #ccd0da;
-  --base: #eff1f5;
-  --mantle: #e6e9ef;
-  --crust: #dce0e8;
+{%- for _, color in flavor.colors %}
+  --{{ color.identifier }}: #{{ color.hex }};
+{%- endfor %}
 }
 
 .ace_gutter {
@@ -54,7 +42,7 @@
 }
 
 .ace_marker-layer .ace_selection {
-  background: rgba(188, 192, 204, 0.80);
+  background: {{ css_rgba(color=surface1_80) }};
 }
 
 
@@ -75,11 +63,11 @@
 }
 
 .ace_marker-layer .ace_active-line {
-  background: rgba(188, 192, 204, 0.32);
+  background: {{ css_rgba(color=surface1_32) }};
 }
 
 .ace_marker-layer .ace_selected-word {
-  border: 1px solid rgba(188, 192, 204, 0.80);
+  border: 1px solid {{ css_rgba(color=surface1_80) }};
 }
 
 .ace_fold {


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.rstheme` files directly, edit the `rstudio.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.