### PR TITLE
Adjusted Background Highlighting of Rmarkdown cells

### DIFF
--- a/catppuccin-frappe.rstheme
+++ b/catppuccin-frappe.rstheme
@@ -45,7 +45,7 @@
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--base);
+  background-color: var(--mantle);
   color: var(--subtext0);
 }
 

--- a/catppuccin-latte.rstheme
+++ b/catppuccin-latte.rstheme
@@ -45,7 +45,7 @@
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--base);
+  background-color: var(--mantle);
   color: var(--subtext0);
 }
 

--- a/catppuccin-macchiato.rstheme
+++ b/catppuccin-macchiato.rstheme
@@ -45,7 +45,7 @@
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--base);
+  background-color: var(--mantle);
   color: var(--subtext0);
 }
 

--- a/catppuccin-mocha.rstheme
+++ b/catppuccin-mocha.rstheme
@@ -45,7 +45,7 @@
 }
 
 .ace_editor, .rstudio-themes-flat.ace_editor_theme .profvis-flamegraph, .rstudio-themes-flat.ace_editor_theme, .rstudio-themes-flat .ace_editor_theme {
-  background-color: var(--base);
+  background-color: var(--mantle);
   color: var(--subtext0);
 }
 


### PR DESCRIPTION
I noticed in issue[]( https://github.com/catppuccin/rstudio/issues/5) that it was hard to read rmarkdown cells in rstudio. So i changed that to use the "mantle" color to make them easier to read. This makes the cell slightly lighter than the rest.